### PR TITLE
ewpi: add optional job number argument to ewpi and pass on to install.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,9 @@ gcc -std=c99 -o ewpi ewpi.c ewpi_map.c
 
 # Usage
 
-./ewpi /path/to/prefix toolchain
+./ewpi /path/to/prefix toolchain [number of make jobs]
 
 Examples :
 
  * ./ewpi $HOME/ewpi_32 i686-w64-mingw32
- * ./ewpi $HOME/ewpi_64 x86_64-w64-mingw32
+ * ./ewpi $HOME/ewpi_64 x86_64-w64-mingw32 4

--- a/ewpi.c
+++ b/ewpi.c
@@ -550,7 +550,7 @@ _ewpi_pkgs_clean(const char *name, const char *url)
 }
 
 static void
-_ewpi_pkgs_install(int i, const char *prefix, const char *host)
+_ewpi_pkgs_install(int i, const char *prefix, const char *host, const char *jobopt)
 {
     char buf[PATH_MAX];
     const char *name;
@@ -582,8 +582,8 @@ _ewpi_pkgs_install(int i, const char *prefix, const char *host)
     }
 
     snprintf(buf, sizeof(buf),
-             "sh ./packages/%s/install.sh %s %s %s %s %s",
-             name, name, tarname, prefix, host, taropt);
+             "sh ./packages/%s/install.sh %s %s %s %s %s %s",
+             name, name, tarname, prefix, host, taropt, jobopt);
     /* fprintf(stderr, "%s\n", buf); */
     fprintf(stderr, "%s: compiling", name);
     fflush(stderr);
@@ -600,8 +600,8 @@ _ewpi_pkgs_install(int i, const char *prefix, const char *host)
 static void
 usage(const char *argv0)
 {
-    fprintf(stderr, "Usage: %s prefix host\n", argv0);
-    fprintf(stderr, "Example: %s $HOME/ewpi i686-w64-mingw32\n", argv0);
+    fprintf(stderr, "Usage: %s prefix host [number of make jobs]\n", argv0);
+    fprintf(stderr, "Example: %s $HOME/ewpi i686-w64-mingw32 4\n", argv0);
     fprintf(stderr, "The prefix must be an absolute directory\n");
     fprintf(stderr, "Possible values for host: i686-w64-mingw32 and x86_64-w64-mingw32\n");
 }
@@ -610,8 +610,9 @@ int main(int argc, char *argv[])
 {
     char *prefix = NULL;
     char *host = NULL;
+    char *jobopt = "";
 
-    if (argc != 3)
+    if (argc < 3)
     {
         usage(argv[0]);
         return 1;
@@ -647,6 +648,9 @@ int main(int argc, char *argv[])
         fprintf(stderr, "Possible values for host: i686-w64-mingw32 and x86_64-w64-mingw32\n");
         return 1;
     }
+
+    if (argv[3])
+        jobopt = argv[3];
 
     if (!ewpi_pkg_dir_set())
     {
@@ -765,7 +769,7 @@ int main(int argc, char *argv[])
             if (_ewpi_pkgs[_ewpi_deps_index[i]].installed)
               continue;
 
-            _ewpi_pkgs_install(i, prefix, host);
+            _ewpi_pkgs_install(i, prefix, host, jobopt);
         }
     }
 #endif /* EWPI_DELETE */

--- a/packages/bullet/install.sh
+++ b/packages/bullet/install.sh
@@ -5,6 +5,7 @@
 # $3 : prefix
 # $4 : host
 # $5 : taropt
+# $6 : jobopt
 
 cd packages/$1 > /dev/null
 dir_name=`tar t$5 $2 | head -1 | cut -f1 -d"/"`
@@ -44,6 +45,6 @@ cmake \
     -G "Unix Makefiles" \
     . > config.log 2>&1
 
-make -j install > make.log 2>&1
+make -j $jobopt install > make.log 2>&1
 
 sed -i -e 's/installed: no/installed: yes/g' ../$1.ewpi

--- a/packages/cairo/install.sh
+++ b/packages/cairo/install.sh
@@ -5,6 +5,7 @@
 # $3 : prefix
 # $4 : host
 # $5 : taropt
+# $6 : jobopt
 
 cd packages/$1 > /dev/null
 dir_name=`tar t$5 $2 | head -1 | cut -f1 -d"/"`
@@ -15,5 +16,5 @@ export PKG_CONFIG_SYSROOOT_DIR=$3
 export CPPFLAGS=-I$3/include
 export LDFLAGS=-L$3/lib
 ./configure --prefix=$3 --host=$4 --disable-static --disable-xlib --disable-quartz --disable-png --enable-ft --disable-gtk-doc-html --disable-ps --disable-pdf --disable-svg > ../config.log 2>&1
-make -j install > ../make.log 2>&1
+make -j $jobopt install > ../make.log 2>&1
 sed -i -e 's/installed: no/installed: yes/g' ../$1.ewpi

--- a/packages/cares/install.sh
+++ b/packages/cares/install.sh
@@ -5,10 +5,11 @@
 # $3 : prefix
 # $4 : host
 # $5 : taropt
+# $6 : jobopt
 
 cd packages/$1 > /dev/null
 dir_name=`tar t$5 $2 | head -1 | cut -f1 -d"/"`
 cd $dir_name
 CPPFLAGS="-D_WIN32_WINNT=0x0600" ./configure --prefix=$3 --host=$4 --disable-static  > ../config.log 2>&1
-make V=0 -j install > ../make.log 2>&1
+make V=0 -j $jobopt install > ../make.log 2>&1
 sed -i -e 's/installed: no/installed: yes/g' ../$1.ewpi

--- a/packages/check/install.sh
+++ b/packages/check/install.sh
@@ -5,10 +5,11 @@
 # $3 : prefix
 # $4 : host
 # $5 : taropt
+# $6 : jobopt
 
 cd packages/$1 > /dev/null
 dir_name=`tar t$5 $2 | head -1 | cut -f1 -d"/"`
 cd $dir_name
 ./configure --prefix=$3 --host=$4 --disable-static --disable-subunit > ../config.log 2>&1
-make -j install > ../make.log 2>&1
+make -j $jobopt install > ../make.log 2>&1
 sed -i -e 's/installed: no/installed: yes/g' ../$1.ewpi

--- a/packages/curl/install.sh
+++ b/packages/curl/install.sh
@@ -5,6 +5,7 @@
 # $3 : prefix
 # $4 : host
 # $5 : taropt
+# $6 : jobopt
 
 cd packages/$1 > /dev/null
 dir_name=`tar t$5 $2 | head -1 | cut -f1 -d"/"`
@@ -15,5 +16,5 @@ export PKG_CONFIG_SYSROOOT_DIR=$3
 export CPPFLAGS=-I$3/include
 export LDFLAGS=-L$3/lib
 ./configure --prefix=$3 --host=$4 --disable-static --with-zlib --with-openssl --with-libssh2 > ../config.log 2>&1
-make -j install > ../make.log 2>&1
+make -j $jobopt install > ../make.log 2>&1
 sed -i -e 's/installed: no/installed: yes/g' ../$1.ewpi

--- a/packages/dbus/install.sh
+++ b/packages/dbus/install.sh
@@ -5,6 +5,7 @@
 # $3 : prefix
 # $4 : host
 # $5 : taropt
+# $6 : jobopt
 
 cd packages/$1 > /dev/null
 dir_name=`tar t$5 $2 | head -1 | cut -f1 -d"/"`
@@ -16,5 +17,5 @@ export PKG_CONFIG_SYSROOOT_DIR=$3
 export CPPFLAGS=-I$3/include
 export LDFLAGS=-L$3/lib
 ./configure --prefix=$3 --host=$4 --disable-static --disable-embedded-tests --disable-modular-tests --disable-tests > ../config.log 2>&1
-make -j install > ../make.log 2>&1
+make -j $jobopt install > ../make.log 2>&1
 sed -i -e 's/installed: no/installed: yes/g' ../$1.ewpi

--- a/packages/expat/install.sh
+++ b/packages/expat/install.sh
@@ -5,10 +5,11 @@
 # $3 : prefix
 # $4 : host
 # $5 : taropt
+# $6 : jobopt
 
 cd packages/$1 > /dev/null
 dir_name=`tar t$5 $2 | head -1 | cut -f1 -d"/"`
 cd $dir_name
 ./configure --prefix=$3 --host=$4 --disable-static --with-docbook=no --without-xmlwf > ../config.log 2>&1
-make -j install > ../make.log 2>&1
+make -j $jobopt install > ../make.log 2>&1
 sed -i -e 's/installed: no/installed: yes/g' ../$1.ewpi

--- a/packages/flac/install.sh
+++ b/packages/flac/install.sh
@@ -5,6 +5,7 @@
 # $3 : prefix
 # $4 : host
 # $5 : taropt
+# $6 : jobopt
 
 cd packages/$1 > /dev/null
 dir_name=`tar t$5 $2 | head -1 | cut -f1 -d"/"`
@@ -15,5 +16,5 @@ export PKG_CONFIG_SYSROOOT_DIR=$3
 export CPPFLAGS=-I$3/include
 export LDFLAGS=-L$3/lib
 ./configure --prefix=$3 --host=$4 --disable-static --with-libiconv-prefix=$3 --disable-cpplibs > ../config.log 2>&1
-make -j install > ../make.log 2>&1
+make -j $jobopt install > ../make.log 2>&1
 sed -i -e 's/installed: no/installed: yes/g' ../$1.ewpi

--- a/packages/fontconfig/install.sh
+++ b/packages/fontconfig/install.sh
@@ -5,6 +5,7 @@
 # $3 : prefix
 # $4 : host
 # $5 : taropt
+# $6 : jobopt
 
 cd packages/$1 > /dev/null
 dir_name=`tar t$5 $2 | head -1 | cut -f1 -d"/"`
@@ -15,5 +16,5 @@ export PKG_CONFIG_SYSROOOT_DIR=$3
 export CPPFLAGS=-I$3/include
 export LDFLAGS=-L$3/lib
 ./configure --prefix=$3 --host=$4 --disable-static --enable-iconv --with-libiconv=$3 --with-expat=$3 --disable-docs > ../config.log 2>&1
-make -j install > ../make.log 2>&1
+make -j $jobopt install > ../make.log 2>&1
 sed -i -e 's/installed: no/installed: yes/g' ../$1.ewpi

--- a/packages/freetype/install.sh
+++ b/packages/freetype/install.sh
@@ -5,6 +5,7 @@
 # $3 : prefix
 # $4 : host
 # $5 : taropt
+# $6 : jobopt
 
 cd packages/$1 > /dev/null
 dir_name=`tar t$5 $2 | head -1 | cut -f1 -d"/"`
@@ -15,5 +16,5 @@ export PKG_CONFIG_SYSROOOT_DIR=$3
 export CPPFLAGS=-I$3/include
 export LDFLAGS=-L$3/lib
 ./configure --prefix=$3 --host=$4 --disable-static --with-bzip2=no > ../config.log 2>&1
-make -j install > ../make.log 2>&1
+make -j $jobopt install > ../make.log 2>&1
 sed -i -e 's/installed: no/installed: yes/g' ../$1.ewpi

--- a/packages/freetype_bootstrap/install.sh
+++ b/packages/freetype_bootstrap/install.sh
@@ -5,6 +5,7 @@
 # $3 : prefix
 # $4 : host
 # $5 : taropt
+# $6 : jobopt
 
 cd packages/$1 > /dev/null
 dir_name=`tar t$5 $2 | head -1 | cut -f1 -d"/"`
@@ -15,5 +16,5 @@ export PKG_CONFIG_SYSROOOT_DIR=$3
 export CPPFLAGS=-I$3/include
 export LDFLAGS=-L$3/lib
 ./configure --prefix=$3 --host=$4 --disable-static --with-harfbuzz=no --with-bzip2=no > ../config.log 2>&1
-make -j install > ../make.log 2>&1
+make -j $jobopt install > ../make.log 2>&1
 sed -i -e 's/installed: no/installed: yes/g' ../$1.ewpi

--- a/packages/fribidi/install.sh
+++ b/packages/fribidi/install.sh
@@ -5,10 +5,11 @@
 # $3 : prefix
 # $4 : host
 # $5 : taropt
+# $6 : jobopt
 
 cd packages/$1 > /dev/null
 dir_name=`tar t$5 $2 | head -1 | cut -f1 -d"/"`
 cd $dir_name
 CPPFLAGS="-DFRIBIDI_ENTRY='__declspec(dllexport)'" ./configure --prefix=$3 --host=$4 --disable-static --disable-debug --disable-deprecated > ../config.log 2>&1
-make -j install > ../make.log 2>&1
+make -j $jobopt install > ../make.log 2>&1
 sed -i -e 's/installed: no/installed: yes/g' ../$1.ewpi

--- a/packages/giflib/install.sh
+++ b/packages/giflib/install.sh
@@ -5,10 +5,11 @@
 # $3 : prefix
 # $4 : host
 # $5 : taropt
+# $6 : jobopt
 
 cd packages/$1 > /dev/null
 dir_name=`tar t$5 $2 | head -1 | cut -f1 -d"/"`
 cd $dir_name
 ./configure --prefix=$3 --host=$4 --disable-static > ../config.log 2>&1
-make -j install > ../make.log 2>&1
+make -j $jobopt install > ../make.log 2>&1
 sed -i -e 's/installed: no/installed: yes/g' ../$1.ewpi

--- a/packages/glib2/install.sh
+++ b/packages/glib2/install.sh
@@ -5,6 +5,7 @@
 # $3 : prefix
 # $4 : host
 # $5 : taropt
+# $6 : jobopt
 
 cd packages/$1 > /dev/null
 dir_name=`tar t$5 $2 | head -1 | cut -f1 -d"/"`

--- a/packages/gst-plugins-base/install.sh
+++ b/packages/gst-plugins-base/install.sh
@@ -5,6 +5,7 @@
 # $3 : prefix
 # $4 : host
 # $5 : taropt
+# $6 : jobopt
 
 cd packages/$1 > /dev/null
 dir_name=`tar t$5 $2 | head -1 | cut -f1 -d"/"`

--- a/packages/gstreamer/install.sh
+++ b/packages/gstreamer/install.sh
@@ -5,6 +5,7 @@
 # $3 : prefix
 # $4 : host
 # $5 : taropt
+# $6 : jobopt
 
 cd packages/$1 > /dev/null
 dir_name=`tar t$5 $2 | head -1 | cut -f1 -d"/"`

--- a/packages/harfbuzz/install.sh
+++ b/packages/harfbuzz/install.sh
@@ -5,6 +5,7 @@
 # $3 : prefix
 # $4 : host
 # $5 : taropt
+# $6 : jobopt
 
 cd packages/$1 > /dev/null
 dir_name=`tar t$5 $2 | head -1 | cut -f1 -d"/"`

--- a/packages/iconv/install.sh
+++ b/packages/iconv/install.sh
@@ -5,10 +5,11 @@
 # $3 : prefix
 # $4 : host
 # $5 : taropt
+# $6 : jobopt
 
 cd packages/$1
 dir_name=`tar t$5 $2 | head -1 | cut -f1 -d"/"`
 cd $dir_name
 make clean > ../make.log 2>&1
-make -j install prefix=$3 CC=$4-gcc AR=$4-ar RANLIB=$4-ranlib DLLTOOL=$4-dlltool >> ../make.log 2>&1
+make -j $jobopt install prefix=$3 CC=$4-gcc AR=$4-ar RANLIB=$4-ranlib DLLTOOL=$4-dlltool >> ../make.log 2>&1
 sed -i -e 's/installed: no/installed: yes/g' ../$1.ewpi

--- a/packages/libffi/install.sh
+++ b/packages/libffi/install.sh
@@ -5,6 +5,7 @@
 # $3 : prefix
 # $4 : host
 # $5 : taropt
+# $6 : jobopt
 
 cd packages/$1 > /dev/null
 dir_name=`tar t$5 $2 | head -1 | cut -f1 -d"/"`
@@ -15,5 +16,5 @@ export PKG_CONFIG_SYSROOOT_DIR=$3
 export CPPFLAGS=-I$3/include
 export LDFLAGS=-L$3/lib
 ./configure --prefix=$3 --host=$4 --disable-static > ../config.log 2>&1
-make -j install > ../make.log 2>&1
+make -j $jobopt install > ../make.log 2>&1
 sed -i -e 's/installed: no/installed: yes/g' ../$1.ewpi

--- a/packages/libidn2/install.sh
+++ b/packages/libidn2/install.sh
@@ -5,6 +5,7 @@
 # $3 : prefix
 # $4 : host
 # $5 : taropt
+# $6 : jobopt
 
 cd packages/$1 > /dev/null
 dir_name=`tar t$5 $2 | head -1 | cut -f1 -d"/"`
@@ -15,5 +16,5 @@ export PKG_CONFIG_SYSROOOT_DIR=$3
 export CPPFLAGS=-I$3/include
 export LDFLAGS=-L$3/lib
 ./configure --prefix=$3 --host=$4 --disable-static --with-libunistring-prefix=$3 --with-libiconv-prefix=$3 --disable-doc > ../config.log 2>&1
-make -j install > ../make.log 2>&1
+make -j $jobopt install > ../make.log 2>&1
 sed -i -e 's/installed: no/installed: yes/g' ../$1.ewpi

--- a/packages/libjpeg/install.sh
+++ b/packages/libjpeg/install.sh
@@ -5,10 +5,11 @@
 # $3 : prefix
 # $4 : host
 # $5 : taropt
+# $6 : jobopt
 
 cd packages/$1 > /dev/null
 dir_name=`tar t$5 $2 | head -1 | cut -f1 -d"/"`
 cd $dir_name
 ./configure --prefix=$3 --host=$4 --disable-static --enable-shared  > ../config.log 2>&1
-make -j install > ../make.log 2>&1
+make -j $jobopt install > ../make.log 2>&1
 sed -i -e 's/installed: no/installed: yes/g' ../$1.ewpi

--- a/packages/libogg/install.sh
+++ b/packages/libogg/install.sh
@@ -5,10 +5,11 @@
 # $3 : prefix
 # $4 : host
 # $5 : taropt
+# $6 : jobopt
 
 cd packages/$1 > /dev/null
 dir_name=`tar t$5 $2 | head -1 | cut -f1 -d"/"` > config.log 2>&1
 cd $dir_name
 ./configure --prefix=$3 --host=$4 --disable-static >> ../config.log 2>&1
-make -j install > ../make.log 2>&1
+make -j $jobopt install > ../make.log 2>&1
 sed -i -e 's/installed: no/installed: yes/g' ../$1.ewpi

--- a/packages/libpng/install.sh
+++ b/packages/libpng/install.sh
@@ -5,6 +5,7 @@
 # $3 : prefix
 # $4 : host
 # $5 : taropt
+# $6 : jobopt
 
 cd packages/$1 > /dev/null
 dir_name=`tar t$5 $2 | head -1 | cut -f1 -d"/"`
@@ -15,5 +16,5 @@ export PKG_CONFIG_SYSROOOT_DIR=$3
 export CPPFLAGS=-I$3/include
 export LDFLAGS=-L$3/lib
 ./configure --prefix=$3 --host=$4 --disable-static --with-zlib-prefix=$3 > ../config.log 2>&1
-make -j install > ../make.log 2>&1
+make -j $jobopt install > ../make.log 2>&1
 sed -i -e 's/installed: no/installed: yes/g' ../$1.ewpi

--- a/packages/libpsl/install.sh
+++ b/packages/libpsl/install.sh
@@ -5,6 +5,7 @@
 # $3 : prefix
 # $4 : host
 # $5 : taropt
+# $6 : jobopt
 
 cd packages/$1 > /dev/null
 dir_name=`tar t$5 $2 | head -1 | cut -f1 -d"/"`
@@ -15,5 +16,5 @@ export PKG_CONFIG_SYSROOOT_DIR=$3
 export CPPFLAGS=-I$3/include
 export LDFLAGS="-L$3/lib -liconv -lws2_32"
 ./configure --prefix=$3 --host=$4 --disable-static --disable-gtk-doc-html --disable-man --with-libiconv-prefix=$3 > ../config.log 2>&1
-make -j install > ../make.log 2>&1
+make -j $jobopt install > ../make.log 2>&1
 sed -i -e 's/installed: no/installed: yes/g' ../$1.ewpi

--- a/packages/libressl/install.sh
+++ b/packages/libressl/install.sh
@@ -5,6 +5,7 @@
 # $3 : prefix
 # $4 : host
 # $5 : taropt
+# $6 : jobopt
 
 cd packages/$1
 dir_name=`tar t$5 $2 | head -1 | cut -f1 -d"/"`

--- a/packages/libsndfile/install.sh
+++ b/packages/libsndfile/install.sh
@@ -5,6 +5,7 @@
 # $3 : prefix
 # $4 : host
 # $5 : taropt
+# $6 : jobopt
 
 cd packages/$1 > /dev/null
 dir_name=`tar t$5 $2 | head -1 | cut -f1 -d"/"`
@@ -15,5 +16,5 @@ export PKG_CONFIG_SYSROOOT_DIR=$3
 export CPPFLAGS=-I$3/include
 export LDFLAGS=-L$3/lib
 ./configure --prefix=$3 --host=$4 --disable-static > ../config.log 2>&1
-make -j install > ../make.log 2>&1
+make -j $jobopt install > ../make.log 2>&1
 sed -i -e 's/installed: no/installed: yes/g' ../$1.ewpi

--- a/packages/libssh2/install.sh
+++ b/packages/libssh2/install.sh
@@ -5,6 +5,7 @@
 # $3 : prefix
 # $4 : host
 # $5 : taropt
+# $6 : jobopt
 
 cd packages/$1 > /dev/null
 dir_name=`tar t$5 $2 | head -1 | cut -f1 -d"/"`
@@ -15,5 +16,5 @@ export PKG_CONFIG_SYSROOOT_DIR=$3
 export CPPFLAGS=-I$3/include
 export LDFLAGS=-L$3/lib
 ./configure --prefix=$3 --host=$4 --disable-static --with-libz --with-openssl > ../config.log 2>&1
-make -j install > ../make.log 2>&1
+make -j $jobopt install > ../make.log 2>&1
 sed -i -e 's/installed: no/installed: yes/g' ../$1.ewpi

--- a/packages/libtheora/install.sh
+++ b/packages/libtheora/install.sh
@@ -5,6 +5,7 @@
 # $3 : prefix
 # $4 : host
 # $5 : taropt
+# $6 : jobopt
 
 cd packages/$1 > /dev/null
 dir_name=`tar t$5 $2 | head -1 | cut -f1 -d"/"`
@@ -15,5 +16,5 @@ export PKG_CONFIG_SYSROOOT_DIR=$3
 export CPPFLAGS=-I$3/include
 export LDFLAGS=-L$3/lib
 ./configure --prefix=$3 --host=$4 --disable-static --disable-spec --disable-examples > ../config.log 2>&1
-make -j install > ../make.log 2>&1
+make -j $jobopt install > ../make.log 2>&1
 sed -i -e 's/installed: no/installed: yes/g' ../$1.ewpi

--- a/packages/libtiff/install.sh
+++ b/packages/libtiff/install.sh
@@ -5,6 +5,7 @@
 # $3 : prefix
 # $4 : host
 # $5 : taropt
+# $6 : jobopt
 
 cd packages/$1 > /dev/null
 dir_name=`tar t$5 $2 | head -1 | cut -f1 -d"/"`
@@ -15,5 +16,5 @@ export PKG_CONFIG_SYSROOOT_DIR=$3
 export CPPFLAGS=-I$3/include
 export LDFLAGS=-L$3/lib
 ./configure --prefix=$3 --host=$4 --disable-static --with-zlib-include-dir=$3/include --with-zlib-lib-dir=$3/lib --with-jpeg-include-dir=$3/include --with-jpeg-lib-dir=$3/lib --with-lzma-include-dir=$3/include --with-lzma-lib-dir=$3/lib > ../config.log 2>&1
-make V=0 -j install > ../make.log 2>&1
+make V=0 -j $jobopt install > ../make.log 2>&1
 sed -i -e 's/installed: no/installed: yes/g' ../$1.ewpi

--- a/packages/libunistring/install.sh
+++ b/packages/libunistring/install.sh
@@ -5,10 +5,11 @@
 # $3 : prefix
 # $4 : host
 # $5 : taropt
+# $6 : jobopt
 
 cd packages/$1 > /dev/null
 dir_name=`tar t$5 $2 | head -1 | cut -f1 -d"/"`
 cd $dir_name
 ./configure --prefix=$3 --host=$4 --disable-static > ../config.log 2>&1
-make -j install > ../make.log 2>&1
+make -j $jobopt install > ../make.log 2>&1
 sed -i -e 's/installed: no/installed: yes/g' ../$1.ewpi

--- a/packages/libvorbis/install.sh
+++ b/packages/libvorbis/install.sh
@@ -5,6 +5,7 @@
 # $3 : prefix
 # $4 : host
 # $5 : taropt
+# $6 : jobopt
 
 cd packages/$1 > /dev/null
 dir_name=`tar t$5 $2 | head -1 | cut -f1 -d"/"`
@@ -15,5 +16,5 @@ export PKG_CONFIG_SYSROOOT_DIR=$3
 export CPPFLAGS=-I$3/include
 export LDFLAGS=-L$3/lib
 ./configure --prefix=$3 --host=$4 --disable-static --disable-oggtest > ../config.log 2>&1
-make -j install > ../make.log 2>&1
+make -j $jobopt install > ../make.log 2>&1
 sed -i -e 's/installed: no/installed: yes/g' ../$1.ewpi

--- a/packages/libwebp/install.sh
+++ b/packages/libwebp/install.sh
@@ -5,6 +5,7 @@
 # $3 : prefix
 # $4 : host
 # $5 : taropt
+# $6 : jobopt
 
 cd packages/$1 > /dev/null
 dir_name=`tar t$5 $2 | head -1 | cut -f1 -d"/"`
@@ -15,5 +16,5 @@ export PKG_CONFIG_SYSROOOT_DIR=$3
 export CPPFLAGS=-I$3/include
 export LDFLAGS=-L$3/lib
 ./configure --prefix=$3 --host=$4 --disable-static --enable-everything --enable-libwebpmux --enable-libwebpdemux --enable-libwebpdecoder --enable-libwebpextras > ../config.log 2>&1
-make -j install > ../make.log 2>&1
+make -j $jobopt install > ../make.log 2>&1
 sed -i -e 's/installed: no/installed: yes/g' ../$1.ewpi

--- a/packages/libxml2/install.sh
+++ b/packages/libxml2/install.sh
@@ -5,6 +5,7 @@
 # $3 : prefix
 # $4 : host
 # $5 : taropt
+# $6 : jobopt
 
 cd packages/$1 > /dev/null
 dir_name=`tar t$5 $2 | head -1 | cut -f1 -d"/"`
@@ -15,5 +16,5 @@ export PKG_CONFIG_SYSROOOT_DIR=$3
 export CPPFLAGS=-I$3/include
 export LDFLAGS=-L$3/lib
 ./configure --prefix=$3 --host=$4 --disable-static --with-python=no > ../config.log 2>&1
-make V=0 -j install > ../make.log 2>&1
+make V=0 -j $jobopt install > ../make.log 2>&1
 sed -i -e 's/installed: no/installed: yes/g' ../$1.ewpi

--- a/packages/luajit/install.sh
+++ b/packages/luajit/install.sh
@@ -5,6 +5,7 @@
 # $3 : prefix
 # $4 : host
 # $5 : taropt
+# $6 : jobopt
 
 cd packages/$1
 dir_name=`tar t$5 $2 | head -1 | cut -f1 -d"/"`

--- a/packages/lz4/install.sh
+++ b/packages/lz4/install.sh
@@ -5,6 +5,7 @@
 # $3 : prefix
 # $4 : host
 # $5 : taropt
+# $6 : jobopt
 
 cd packages/$1 > /dev/null
 dir_name=`tar t$5 $2 | head -1 | cut -f1 -d"/"`

--- a/packages/nghttp2/install.sh
+++ b/packages/nghttp2/install.sh
@@ -5,6 +5,7 @@
 # $3 : prefix
 # $4 : host
 # $5 : taropt
+# $6 : jobopt
 
 cd packages/$1 > /dev/null
 dir_name=`tar t$5 $2 | head -1 | cut -f1 -d"/"`
@@ -15,5 +16,5 @@ export PKG_CONFIG_SYSROOOT_DIR=$3
 export CPPFLAGS=-I$3/include
 export LDFLAGS=-L$3/lib
 ./configure --prefix=$3 --host=$4 --disable-static --enable-lib-only > ../config.log 2>&1
-make -j install > ../make.log 2>&1
+make -j $jobopt install > ../make.log 2>&1
 sed -i -e 's/installed: no/installed: yes/g' ../$1.ewpi

--- a/packages/openjpeg/install.sh
+++ b/packages/openjpeg/install.sh
@@ -5,6 +5,7 @@
 # $3 : prefix
 # $4 : host
 # $5 : taropt
+# $6 : jobopt
 
 cd packages/$1 > /dev/null
 dir_name=`tar t$5 $2 | head -1 | cut -f1 -d"/"`
@@ -39,6 +40,6 @@ cmake \
     -G "Unix Makefiles" \
     . > ../config.log 2>&1
 
-make -j install > ../make.log 2>&1
+make -j $jobopt install > ../make.log 2>&1
 
 sed -i -e 's/installed: no/installed: yes/g' ../$1.ewpi

--- a/packages/opus/install.sh
+++ b/packages/opus/install.sh
@@ -5,6 +5,7 @@
 # $3 : prefix
 # $4 : host
 # $5 : taropt
+# $6 : jobopt
 
 cd packages/$1 > /dev/null
 dir_name=`tar t$5 $2 | head -1 | cut -f1 -d"/"`
@@ -15,5 +16,5 @@ export PKG_CONFIG_SYSROOOT_DIR=$3
 export CPPFLAGS=-I$3/include
 export LDFLAGS=-L$3/lib
 ./configure --prefix=$3 --host=$4 --disable-static > ../config.log 2>&1
-make -j install > ../make.log 2>&1
+make -j $jobopt install > ../make.log 2>&1
 sed -i -e 's/installed: no/installed: yes/g' ../$1.ewpi

--- a/packages/orc/install.sh
+++ b/packages/orc/install.sh
@@ -5,6 +5,7 @@
 # $3 : prefix
 # $4 : host
 # $5 : taropt
+# $6 : jobopt
 
 cd packages/$1 > /dev/null
 dir_name=`tar t$5 $2 | head -1 | cut -f1 -d"/"`
@@ -15,5 +16,5 @@ export PKG_CONFIG_SYSROOOT_DIR=$3
 export CPPFLAGS=-I$3/include
 export LDFLAGS=-L$3/lib
 ./configure --prefix=$3 --host=$4 --disable-static --disable-tests > ../config.log 2>&1
-make -j install > ../make.log 2>&1
+make -j $jobopt install > ../make.log 2>&1
 sed -i -e 's/installed: no/installed: yes/g' ../$1.ewpi

--- a/packages/pixman/install.sh
+++ b/packages/pixman/install.sh
@@ -5,10 +5,11 @@
 # $3 : prefix
 # $4 : host
 # $5 : taropt
+# $6 : jobopt
 
 cd packages/$1 > /dev/null
 dir_name=`tar t$5 $2 | head -1 | cut -f1 -d"/"`
 cd $dir_name
 ./configure --prefix=$3 --host=$4 --disable-static --disable-gtk --disable-libpng > ../config.log 2>&1
-make -j install > ../make.log 2>&1
+make -j $jobopt install > ../make.log 2>&1
 sed -i -e 's/installed: no/installed: yes/g' ../$1.ewpi

--- a/packages/pkg-config/install.sh
+++ b/packages/pkg-config/install.sh
@@ -5,10 +5,11 @@
 # $3 : prefix
 # $4 : host
 # $5 : taropt
+# $6 : jobopt
 
 cd packages/$1 &> /dev/null
 dir_name=`tar t$5 $2 | head -1 | cut -f1 -d"/"`
 cd $dir_name
 ./configure --prefix=$3 --host=$4 --disable-static --with-internal-glib=yes &> ../config.log
-make -j install &> ../make.log
+make -j $jobopt install &> ../make.log
 sed -i -e 's/installed: no/installed: yes/g' ../$1.ewpi

--- a/packages/regex/install.sh
+++ b/packages/regex/install.sh
@@ -5,6 +5,7 @@
 # $3 : prefix
 # $4 : host
 # $5 : taropt
+# $6 : jobopt
 
 cd packages/$1 > /dev/null
 dir_name=`tar t$5 $2 | head -1 | cut -f1 -d"/"`

--- a/packages/xz/install.sh
+++ b/packages/xz/install.sh
@@ -5,10 +5,11 @@
 # $3 : prefix
 # $4 : host
 # $5 : taropt
+# $6 : jobopt
 
 cd packages/$1 > /dev/null
 dir_name=`tar t$5 $2 | head -1 | cut -f1 -d"/"`
 cd $dir_name
 ./configure --prefix=$3 --host=$4 --disable-static --enable-threads=vista --disable-lzmainfo --disable-lzma-links --disable-scripts --disable-doc --disable-cxx > ../config.log 2>&1
-make V=0 -j install > ../make.log 2>&1
+make V=0 -j $jobopt install > ../make.log 2>&1
 sed -i -e 's/installed: no/installed: yes/g' ../$1.ewpi

--- a/packages/zlib/install.sh
+++ b/packages/zlib/install.sh
@@ -5,11 +5,12 @@
 # $3 : prefix
 # $4 : host
 # $5 : taropt
+# $6 : jobopt
 
 cd packages/$1
 dir_name=`tar t$5 $2 | head -1 | cut -f1 -d"/"`
 cp Makefile $dir_name/win32
 cd $dir_name
 make -f win32/Makefile clean > /dev/null
-make -j -f win32/Makefile install prefix=$3 PREFIX=$4 > ../make.log 2>&1
+make -j $jobopt -f win32/Makefile install prefix=$3 PREFIX=$4 > ../make.log 2>&1
 sed -i -e 's/installed: no/installed: yes/g' ../$1.ewpi


### PR DESCRIPTION
The default still stay -j without number to use as much jobs as
possible. For more constraints systems though one could pass some low
number to make sure the build still completes or does not put the system
under heavy load.

This patch also add the -j option to ninja based builds. On the other
hand it does not touch the package using make but having no -j usage
yet. I assume there is a reason they are not having it yet and I wanted
to avoid breaking them.