### PR TITLE
ewpi: make sure the install script exists directly on a non-zero return

### DIFF
--- a/packages/bullet/install.sh
+++ b/packages/bullet/install.sh
@@ -1,5 +1,7 @@
 #! /bin/sh
 
+set -e
+
 # $1 : name
 # $2 : tarname
 # $3 : prefix

--- a/packages/cairo/install.sh
+++ b/packages/cairo/install.sh
@@ -1,5 +1,7 @@
 #! /bin/sh
 
+set -e
+
 # $1 : name
 # $2 : tarname
 # $3 : prefix

--- a/packages/cares/install.sh
+++ b/packages/cares/install.sh
@@ -1,5 +1,7 @@
 #! /bin/sh
 
+set -e
+
 # $1 : name
 # $2 : tarname
 # $3 : prefix

--- a/packages/check/install.sh
+++ b/packages/check/install.sh
@@ -1,5 +1,7 @@
 #! /bin/sh
 
+set -e
+
 # $1 : name
 # $2 : tarname
 # $3 : prefix

--- a/packages/curl/install.sh
+++ b/packages/curl/install.sh
@@ -1,5 +1,7 @@
 #! /bin/sh
 
+set -e
+
 # $1 : name
 # $2 : tarname
 # $3 : prefix

--- a/packages/dbus/install.sh
+++ b/packages/dbus/install.sh
@@ -1,5 +1,7 @@
 #! /bin/sh
 
+set -e
+
 # $1 : name
 # $2 : tarname
 # $3 : prefix

--- a/packages/expat/install.sh
+++ b/packages/expat/install.sh
@@ -1,5 +1,7 @@
 #! /bin/sh
 
+set -e
+
 # $1 : name
 # $2 : tarname
 # $3 : prefix

--- a/packages/flac/install.sh
+++ b/packages/flac/install.sh
@@ -1,5 +1,7 @@
 #! /bin/sh
 
+set -e
+
 # $1 : name
 # $2 : tarname
 # $3 : prefix

--- a/packages/fontconfig/install.sh
+++ b/packages/fontconfig/install.sh
@@ -1,5 +1,7 @@
 #! /bin/sh
 
+set -e
+
 # $1 : name
 # $2 : tarname
 # $3 : prefix

--- a/packages/freetype/install.sh
+++ b/packages/freetype/install.sh
@@ -1,5 +1,7 @@
 #! /bin/sh
 
+set -e
+
 # $1 : name
 # $2 : tarname
 # $3 : prefix

--- a/packages/freetype_bootstrap/install.sh
+++ b/packages/freetype_bootstrap/install.sh
@@ -1,5 +1,7 @@
 #! /bin/sh
 
+set -e
+
 # $1 : name
 # $2 : tarname
 # $3 : prefix

--- a/packages/fribidi/install.sh
+++ b/packages/fribidi/install.sh
@@ -1,5 +1,7 @@
 #! /bin/sh
 
+set -e
+
 # $1 : name
 # $2 : tarname
 # $3 : prefix

--- a/packages/giflib/install.sh
+++ b/packages/giflib/install.sh
@@ -1,5 +1,7 @@
 #! /bin/sh
 
+set -e
+
 # $1 : name
 # $2 : tarname
 # $3 : prefix

--- a/packages/glib2/install.sh
+++ b/packages/glib2/install.sh
@@ -1,5 +1,7 @@
 #! /bin/sh
 
+set -e
+
 # $1 : name
 # $2 : tarname
 # $3 : prefix

--- a/packages/gst-plugins-base/install.sh
+++ b/packages/gst-plugins-base/install.sh
@@ -1,5 +1,7 @@
 #! /bin/sh
 
+set -e
+
 # $1 : name
 # $2 : tarname
 # $3 : prefix

--- a/packages/gstreamer/install.sh
+++ b/packages/gstreamer/install.sh
@@ -1,5 +1,7 @@
 #! /bin/sh
 
+set -e
+
 # $1 : name
 # $2 : tarname
 # $3 : prefix

--- a/packages/harfbuzz/install.sh
+++ b/packages/harfbuzz/install.sh
@@ -1,5 +1,7 @@
 #! /bin/sh
 
+set -e
+
 # $1 : name
 # $2 : tarname
 # $3 : prefix

--- a/packages/iconv/install.sh
+++ b/packages/iconv/install.sh
@@ -1,5 +1,7 @@
 #! /bin/sh
 
+set -e
+
 # $1 : name
 # $2 : tarname
 # $3 : prefix

--- a/packages/libidn2/install.sh
+++ b/packages/libidn2/install.sh
@@ -1,5 +1,7 @@
 #! /bin/sh
 
+set -e
+
 # $1 : name
 # $2 : tarname
 # $3 : prefix

--- a/packages/libjpeg/install.sh
+++ b/packages/libjpeg/install.sh
@@ -1,5 +1,7 @@
 #! /bin/sh
 
+set -e
+
 # $1 : name
 # $2 : tarname
 # $3 : prefix

--- a/packages/libogg/install.sh
+++ b/packages/libogg/install.sh
@@ -1,5 +1,7 @@
 #! /bin/sh
 
+set -e
+
 # $1 : name
 # $2 : tarname
 # $3 : prefix

--- a/packages/libpng/install.sh
+++ b/packages/libpng/install.sh
@@ -1,5 +1,7 @@
 #! /bin/sh
 
+set -e
+
 # $1 : name
 # $2 : tarname
 # $3 : prefix

--- a/packages/libpsl/install.sh
+++ b/packages/libpsl/install.sh
@@ -1,5 +1,7 @@
 #! /bin/sh
 
+set -e
+
 # $1 : name
 # $2 : tarname
 # $3 : prefix

--- a/packages/libressl/install.sh
+++ b/packages/libressl/install.sh
@@ -1,5 +1,7 @@
 #! /bin/sh
 
+set -e
+
 # $1 : name
 # $2 : tarname
 # $3 : prefix

--- a/packages/libsndfile/install.sh
+++ b/packages/libsndfile/install.sh
@@ -1,5 +1,7 @@
 #! /bin/sh
 
+set -e
+
 # $1 : name
 # $2 : tarname
 # $3 : prefix

--- a/packages/libssh2/install.sh
+++ b/packages/libssh2/install.sh
@@ -1,5 +1,7 @@
 #! /bin/sh
 
+set -e
+
 # $1 : name
 # $2 : tarname
 # $3 : prefix

--- a/packages/libtheora/install.sh
+++ b/packages/libtheora/install.sh
@@ -1,5 +1,7 @@
 #! /bin/sh
 
+set -e
+
 # $1 : name
 # $2 : tarname
 # $3 : prefix

--- a/packages/libtiff/install.sh
+++ b/packages/libtiff/install.sh
@@ -1,5 +1,7 @@
 #! /bin/sh
 
+set -e
+
 # $1 : name
 # $2 : tarname
 # $3 : prefix

--- a/packages/libunistring/install.sh
+++ b/packages/libunistring/install.sh
@@ -1,5 +1,7 @@
 #! /bin/sh
 
+set -e
+
 # $1 : name
 # $2 : tarname
 # $3 : prefix

--- a/packages/libvorbis/install.sh
+++ b/packages/libvorbis/install.sh
@@ -1,5 +1,7 @@
 #! /bin/sh
 
+set -e
+
 # $1 : name
 # $2 : tarname
 # $3 : prefix

--- a/packages/libwebp/install.sh
+++ b/packages/libwebp/install.sh
@@ -1,5 +1,7 @@
 #! /bin/sh
 
+set -e
+
 # $1 : name
 # $2 : tarname
 # $3 : prefix

--- a/packages/libxml2/install.sh
+++ b/packages/libxml2/install.sh
@@ -1,5 +1,7 @@
 #! /bin/sh
 
+set -e
+
 # $1 : name
 # $2 : tarname
 # $3 : prefix

--- a/packages/luajit/install.sh
+++ b/packages/luajit/install.sh
@@ -1,5 +1,7 @@
 #! /bin/sh
 
+set -e
+
 # $1 : name
 # $2 : tarname
 # $3 : prefix

--- a/packages/lz4/install.sh
+++ b/packages/lz4/install.sh
@@ -1,5 +1,7 @@
 #! /bin/sh
 
+set -e
+
 # $1 : name
 # $2 : tarname
 # $3 : prefix

--- a/packages/nghttp2/install.sh
+++ b/packages/nghttp2/install.sh
@@ -1,5 +1,7 @@
 #! /bin/sh
 
+set -e
+
 # $1 : name
 # $2 : tarname
 # $3 : prefix

--- a/packages/openjpeg/install.sh
+++ b/packages/openjpeg/install.sh
@@ -1,5 +1,7 @@
 #! /bin/sh
 
+set -e
+
 # $1 : name
 # $2 : tarname
 # $3 : prefix

--- a/packages/opus/install.sh
+++ b/packages/opus/install.sh
@@ -1,5 +1,7 @@
 #! /bin/sh
 
+set -e
+
 # $1 : name
 # $2 : tarname
 # $3 : prefix

--- a/packages/orc/install.sh
+++ b/packages/orc/install.sh
@@ -1,5 +1,7 @@
 #! /bin/sh
 
+set -e
+
 # $1 : name
 # $2 : tarname
 # $3 : prefix

--- a/packages/pixman/install.sh
+++ b/packages/pixman/install.sh
@@ -1,5 +1,7 @@
 #! /bin/sh
 
+set -e
+
 # $1 : name
 # $2 : tarname
 # $3 : prefix

--- a/packages/pkg-config/install.sh
+++ b/packages/pkg-config/install.sh
@@ -1,5 +1,7 @@
 #! /bin/sh
 
+set -e
+
 # $1 : name
 # $2 : tarname
 # $3 : prefix

--- a/packages/regex/install.sh
+++ b/packages/regex/install.sh
@@ -1,5 +1,7 @@
 #! /bin/sh
 
+set -e
+
 # $1 : name
 # $2 : tarname
 # $3 : prefix

--- a/packages/xz/install.sh
+++ b/packages/xz/install.sh
@@ -1,5 +1,7 @@
 #! /bin/sh
 
+set -e
+
 # $1 : name
 # $2 : tarname
 # $3 : prefix

--- a/packages/zlib/install.sh
+++ b/packages/zlib/install.sh
@@ -1,5 +1,7 @@
 #! /bin/sh
 
+set -e
+
 # $1 : name
 # $2 : tarname
 # $3 : prefix


### PR DESCRIPTION
If not we would only use the return code of the last command (a always
successful sed right now) to evaluate if the package was handled
correctly. Instead we now break out if any command fails on the way.