### PR TITLE
Fix libsnappy's install.sh script

### DIFF
--- a/packages/libsnappy/install.sh
+++ b/packages/libsnappy/install.sh
@@ -30,4 +30,4 @@ cmake \
     -G "Unix Makefiles" \
     . >> ../config.log 2>&1
 
-make -j $5 install > ../make.log 2>&1
+make -j $jobopt install > ../make.log 2>&1


### PR DESCRIPTION
Fixes installing libsnappy without --job flag