### PR TITLE
libbs2b: unset AC_FUNC_MALLOC to avoid cross compilation problems

### DIFF
--- a/packages/libbs2b/install.sh
+++ b/packages/libbs2b/install.sh
@@ -3,6 +3,7 @@
 . ../../common.sh
 
 sed -i -e 's/libbs2b_la_LDFLAGS =/libbs2b_la_LDFLAGS = -no-undefined/g' src/Makefile.in
+sed -i -e 's/AC_FUNC_MALLOC//' configure.ac
 
 ./configure --prefix=$3 --host=$4 --disable-static > ../config.log 2>&1
 


### PR DESCRIPTION
This fixes a cross compilation problem for me, erroring out in
rpl_malloc undefined. Idea for the fix taken from:

https://github.com/rdp/ffmpeg-windows-build-helpers/issues/270