### PR TITLE
Fixes crashes when we modify dependencies in ewpi packages

### DIFF
--- a/ewpi.c
+++ b/ewpi.c
@@ -857,9 +857,12 @@ _ew_packages_not_installed_disp(void)
     fflush(stdout);
     for (int i = 0; i < _ew_package_count_total; i++)
     {
-        int idx = _ew_package_index[i];
-        if (!_ewpi_pkgs[idx].installed)
-            printf("  %s-%s\n", _ewpi_pkgs[idx].name, _ewpi_pkgs[idx].version);
+        if (i < _ew_package_deps_dst_count)
+        {
+           int idx = _ew_package_index[i];
+           if (!_ewpi_pkgs[idx].installed)
+             printf("  %s-%s\n", _ewpi_pkgs[idx].name, _ewpi_pkgs[idx].version);
+        }
     }
     printf("\n");
     fflush(stdout);
@@ -873,7 +876,7 @@ _ew_packages_download(void)
     int count;
 
     count = 0;
-    for (int i = 0; i < _ew_package_count_total; i++)
+    for (int i = 0; i < _ew_package_deps_dst_count; i++)
     {
         iter = _ewpi_pkgs + _ew_package_index[i];
         strcpy(buf, _ew_package_dir_dst);
@@ -891,7 +894,7 @@ _ew_packages_download(void)
 
     printf(":: Download sources...\n");
     fflush(stdout);
-    for (int i = 0; i < _ew_package_count_total; i++)
+    for (int i = 0; i < _ew_package_deps_dst_count; i++)
     {
         int ret;
 
@@ -956,7 +959,7 @@ _ew_packages_longest_name()
     Package *iter;
 
     /* compute the largest name (including version) of the packages */
-    for (int i = 0; i < _ew_package_count_total; i++)
+    for (int i = 0; i < _ew_package_deps_dst_count; i++)
     {
         iter = _ewpi_pkgs + _ew_package_index[i];
         if ((int)(strlen(iter->name) + 1 + strlen(iter->version)) > _ew_package_name_size_max)
@@ -1039,7 +1042,7 @@ _ew_packages_extract(int verbose)
     int c;
 
     count = 0;
-    for (int i = 0; i < _ew_package_count_total; i++)
+    for (int i = 0; i < _ew_package_deps_dst_count; i++)
     {
         iter = _ewpi_pkgs + _ew_package_index[i];
         strcpy(buf, _ew_package_dir_dst);
@@ -1059,7 +1062,7 @@ _ew_packages_extract(int verbose)
     fflush(stdout);
 
     c = 0;
-    for (int i = 0; i < _ew_package_count_total; i++)
+    for (int i = 0; i < _ew_package_deps_dst_count; i++)
     {
         const char *name;
         const char *tarname;


### PR DESCRIPTION
The crash happens because the _ew_package_index is not filled for dependencies not found in the current compilation, but array is iterated over all indices anyway, instead of just the dependencies dst count.

The array returns garbage which is then dereferenced in _ewpi_pkgs and crashes.

This patch makes this iterate over just the dependencies instead, and as such doesn't iterate over uninitialized array elements.